### PR TITLE
fix: Allow github.io domains to be parsed

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,17 +73,25 @@ func parseCategory(lineGroup []string, category string, subCategory string, spec
 		item := MarkdownRepo{
 			ProjectName:     string(match[1]),
 			URL:             string(match[2]),
-			Description:     string(match[6]),
+			Description:     string(match[7]),
 			Category:        category,
 			SubCategory:     subCategory,
 			SpecialCategory: specialCategory,
 		}
 
-		if string(match[3]) != "" {
+		if strings.Contains(string(match[2]), ".github.io") {
+			item.OwnerName = string(match[3])
+			repoName := strings.TrimPrefix(string(match[4]), "/")
+			if repoName != "" {
+				item.RepoName = repoName
+			} else {
+				item.RepoName = item.OwnerName + ".github.io"
+			}
+		} else if string(match[3]) != "" {
 			item.GithubPagesName = string(match[3])
 		} else {
-			item.OwnerName = string(match[4])
-			item.RepoName = string(match[5])
+			item.OwnerName = string(match[5])
+			item.RepoName = string(match[6])
 		}
 
 		items = append(items, item)
@@ -459,7 +467,7 @@ func getText(URL string) string {
 }
 
 func parseGithubsURLRegex(text string) [][][]byte {
-	reRepo := regexp.MustCompile(`\[([a-zA-Z0-9-_\/ ]+)\]\((https:\/\/(?:([a-zA-Z0-9-._]+)\.)?(?:github\.io|github\.com\/([a-zA-Z0-9-._]+)\/([a-zA-Z0-9-._]+)))\)(?: - (.+))`)
+	reRepo := regexp.MustCompile(`\[([a-zA-Z0-9-_\/ ]+)\]\((https:\/\/(?:([a-zA-Z0-9-._]+)\.)?(?:github\.io(\/[a-zA-Z0-9-._]*)?|github\.com\/([a-zA-Z0-9-._]+)\/([a-zA-Z0-9-._]+)))\)(?: - (.+))`)
 	return reRepo.FindAllSubmatch([]byte(text), -1)
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseGithubsURLRegex(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected [][][]byte
+	}{
+		{
+			name:  "Standard github.com URL",
+			input: "[awesome-go](https://github.com/avelino/awesome-go) - A curated list of awesome Go frameworks, libraries and software.",
+			expected: [][][]byte{
+				{
+					[]byte("[awesome-go](https://github.com/avelino/awesome-go) - A curated list of awesome Go frameworks, libraries and software."),
+					[]byte("awesome-go"),
+					[]byte("https://github.com/avelino/awesome-go"),
+					nil, // subdomain
+					nil, // github.io path
+					[]byte("avelino"),
+					[]byte("awesome-go"),
+					[]byte("A curated list of awesome Go frameworks, libraries and software."),
+				},
+			},
+		},
+		{
+			name:  "github.io URL without path",
+			input: "[gilbert](https://go-gilbert.github.io) - Buildsystem and task runner for Go projects.",
+			expected: [][][]byte{
+				{
+					[]byte("[gilbert](https://go-gilbert.github.io) - Buildsystem and task runner for Go projects."),
+					[]byte("gilbert"),
+					[]byte("https://go-gilbert.github.io"),
+					[]byte("go-gilbert"),
+					nil, // github.io path
+					nil, // github.com owner
+					nil, // github.com repo
+					[]byte("Buildsystem and task runner for Go projects."),
+				},
+			},
+		},
+		{
+			name:  "github.io URL with path",
+			input: "[my-project](https://my-user.github.io/my-project) - My awesome project.",
+			expected: [][][]byte{
+				{
+					[]byte("[my-project](https://my-user.github.io/my-project) - My awesome project."),
+					[]byte("my-project"),
+					[]byte("https://my-user.github.io/my-project"),
+					[]byte("my-user"),
+					[]byte("/my-project"),
+					nil, // github.com owner
+					nil, // github.com repo
+					[]byte("My awesome project."),
+				},
+			},
+		},
+		{
+			name:  "github.com URL with subdomain",
+			input: "[status](https://status.github.com/owner/repo) - Status page.",
+			expected: [][][]byte{
+				{
+					[]byte("[status](https://status.github.com/owner/repo) - Status page."),
+					[]byte("status"),
+					[]byte("https://status.github.com/owner/repo"),
+					[]byte("status"),
+					nil, // github.io path
+					[]byte("owner"),
+					[]byte("repo"),
+					[]byte("Status page."),
+				},
+			},
+		},
+		{
+			name:     "No URL in text",
+			input:    "This is just some text without a URL.",
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := parseGithubsURLRegex(tc.input)
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("Test case '%s' failed.\nExpected:\n%#v\nGot:\n%#v", tc.name, tc.expected, actual)
+				if len(actual) > 0 && len(tc.expected) > 0 && len(actual[0]) == len(tc.expected[0]) {
+					for i := range actual[0] {
+						if !reflect.DeepEqual(actual[0][i], tc.expected[0][i]) {
+							t.Errorf("Mismatch at index %d:\nExpected: %s\nGot:      %s", i, tc.expected[0][i], actual[0][i])
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The previous implementation incorrectly classified all github.io domains as custom domains and skipped them.

This change updates the URL parsing logic to correctly handle github.io domains, extracting the owner and repository information from the URL. This allows projects hosted on github.io to be included in the processed list of repositories.